### PR TITLE
Move the Nadeo UI widget when playing in rounds-based modes.

### DIFF
--- a/teemann/currentcps/__init__.py
+++ b/teemann/currentcps/__init__.py
@@ -54,6 +54,10 @@ class CurrentCPs(AppConfig):
         self.instance.signal_manager.listen(mp_signals.map.map_start__end, self.map_end)
         self.instance.signal_manager.listen(mp_signals.player.player_enter_spectator_slot, self.player_enter_spec)
 
+        # Make sure we move the rounds_scores and other gui elements.
+        self.instance.ui_manager.properties.set_attribute('round_scores', 'pos', '-126.5 87. 150.')
+        self.instance.ui_manager.properties.set_attribute('multilap_info', 'pos', '107., 88., 5.')
+
         self.widget = CPWidgetView(self)
         # await self.widget.display()
         await self.update_view()


### PR DESCRIPTION
Prevent the Rounds Results to be displayed inside of the Current CPs widget.